### PR TITLE
Fix typos in comments

### DIFF
--- a/src/com/google/guiceberry/DefaultEnvSelector.java
+++ b/src/com/google/guiceberry/DefaultEnvSelector.java
@@ -164,7 +164,7 @@ public class DefaultEnvSelector implements GuiceBerryEnvSelector {
    * <p>For details about this feature, see tutorial TODO
    *
    * <p>This method is a convenience method in case you wish to set that system
-   * property programatically.
+   * property programmatically.
    *
    * <p>Note that this override is honored by code inside the {@link #of}
    * methods, so this {@link #override} method must be called <em>before</em>

--- a/src/com/google/guiceberry/GuiceBerry.java
+++ b/src/com/google/guiceberry/GuiceBerry.java
@@ -57,7 +57,7 @@ public class GuiceBerry {
   }
   
   /**
-   * You won't need to deal with this interface unless you are writting an
+   * You won't need to deal with this interface unless you are writing an
    * adapter to a test framework. See {@link GuiceBerry}.
    * 
    * <p>The two methods in this interface should "wrap" a test execution. I.e.

--- a/src/com/google/guiceberry/GuiceBerryModule.java
+++ b/src/com/google/guiceberry/GuiceBerryModule.java
@@ -28,7 +28,7 @@ import com.google.inject.Scope;
 /**
  * This Module provides the basic bindings required by GuiceBerry, namely
  * {@link TestId}, {@link TearDownAccepter} and the {@link TestScoped} scope.
- * Without these bindinds, GuiceBerry will fail to set up. Therefore, this
+ * Without these bindings, GuiceBerry will fail to set up. Therefore, this
  * module is required to be installed by all GuiceBerry Envs (see
  * {@link GuiceBerryEnvSelector}).
  *

--- a/src/com/google/guiceberry/controllable/ControllableInjectionClientModule.java
+++ b/src/com/google/guiceberry/controllable/ControllableInjectionClientModule.java
@@ -25,7 +25,7 @@ import com.google.guiceberry.TestId;
 import java.util.Map;
 
 /**
- * This internal class is basically what the {@link IcMaster} uses to fullfil
+ * This internal class is basically what the {@link IcMaster} uses to fulfill
  * its {@link IcMaster#buildClientModule()} method.
  * 
  * @author Luiz-Otavio Zorzella

--- a/src/com/google/guiceberry/controllable/ControllableInjectionServerModule.java
+++ b/src/com/google/guiceberry/controllable/ControllableInjectionServerModule.java
@@ -24,7 +24,7 @@ import com.google.guiceberry.controllable.IcStrategy.ServerSupport;
 import java.util.Map;
 
 /**
- * This internal class is basically what the {@link IcMaster} uses to fullfil
+ * This internal class is basically what the {@link IcMaster} uses to fulfill
  * its {@link IcMaster#buildServerModule(java.util.Collection)} method.
  * 
  * @author Luiz-Otavio Zorzella

--- a/src/com/google/guiceberry/controllable/IcStrategy.java
+++ b/src/com/google/guiceberry/controllable/IcStrategy.java
@@ -32,7 +32,7 @@ import com.google.inject.util.Types;
  * such as HTTP {@link javax.servlet.http.Cookie}s, {@link java.io.File}s in a 
  * shared disk, shared database tables and whatnot.
  * 
- * <p>This class makes the implementation of these stretegies possible. Each
+ * <p>This class makes the implementation of these strategies possible. Each
  * of these would simply require an implementation of the 
  * {@link IcStrategy.ClientSupport} and {@link IcStrategy.ServerSupport} 
  * interfaces.
@@ -47,7 +47,7 @@ import com.google.inject.util.Types;
  * {@link IcStrategy.ClientSupport#resetOverride(ControllableId)} methods are
  * <em>indirectly</em> exposed to the end-user through 
  * {@link InjectionController#setOverride(Object)} and {@link InjectionController#resetOverride()}
- * respectivelly.
+ * respectively.
  * 
  * <p>Finally, note that some strategies might be fundamentally more "capable"
  * than others. E.g. a non-serializable class would pose a problem for a 
@@ -75,7 +75,7 @@ public class IcStrategy {
      * {@link IcStrategy.ServerSupport#getOverride(ControllableId, Provider)}
      * for this {@code controllableId} should return {@code override}.
      * 
-     * <p>It is considered ok for a test to call 
+     * <p>It is considered OK for a test to call 
      * {@link InjectionController#setOverride(Object)} multiple times, so this method
      * must also support it.
      */
@@ -107,7 +107,7 @@ public class IcStrategy {
      * Returns true if the {@code controllableId} is currently being controlled.
      * 
      * <p>When this returns true, the framework will call 
-     * {@link #getOverride(ControllableId, Provider)} to fullfil an injection, 
+     * {@link #getOverride(ControllableId, Provider)} to fulfill an injection, 
      * otherwise it will bypass it.
      */
     <T> boolean isControlled(ControllableId<T> controllableId);
@@ -116,7 +116,7 @@ public class IcStrategy {
      * Returns the current override for this Injection. The framework will 
      * never call this method unless {@link #isControlled(ControllableId)} 
      * returns true, so calling this method while not controlling an injection
-     * is illegal and the outcode is unspecified (though it's conceivably 
+     * is illegal and the outcome is unspecified (though it's conceivably 
      * possible to subvert the system with a race condition).
      * 
      * @param delegate what the server would return in absence of this injection 

--- a/src/com/google/guiceberry/controllable/InjectionController.java
+++ b/src/com/google/guiceberry/controllable/InjectionController.java
@@ -58,7 +58,7 @@ public interface InjectionController<T> {
    * href="http://www.google.com/codesearch/p?hl=en#yL0uRk1mhCY/trunk/doc/tutorial/test/testng/tutorial_1_server/Example4InjectionControllerTest.java">
    * Example4InjectionControllerTest.java tutorial</a> and others.
    * 
-   * <p>It is ok for a test to call this method multiple times.
+   * <p>It is OK for a test to call this method multiple times.
    */
   void setOverride(T override);
   
@@ -69,7 +69,7 @@ public interface InjectionController<T> {
    * test, so you do not need to. This is only provided in case you need to 
    * do so to complete the test altogether.
    * 
-   * <p>It is ok for a test to call this method multiple times, even when
+   * <p>It is OK for a test to call this method multiple times, even when
    * the injection is not currently being controlled, in which case it will
    * be a no-op.
    */

--- a/src/com/google/guiceberry/controllable/InterceptingBindingsBuilder.java
+++ b/src/com/google/guiceberry/controllable/InterceptingBindingsBuilder.java
@@ -187,7 +187,7 @@ final class InterceptingBindingsBuilder {
 
       // we scope the user's provider, not the interceptor. This is dangerous,
       // but convenient. It means that although the user's provider will live
-      // in its proper scope, the intereptor gets invoked without a scope
+      // in its proper scope, the interceptor gets invoked without a scope
       applyScoping(binding, scopedBindingBuilder);
 
       keysIntercepted.add(key);

--- a/src/com/google/guiceberry/controllable/ModuleWriter.java
+++ b/src/com/google/guiceberry/controllable/ModuleWriter.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Annotation;
  * @author Jesse Wilson
  * @author Luiz-Otavio Zorzella
  */
-//TODO: document and move to guice?
+//TODO: document and move to Guice?
 class ModuleWriter extends DefaultElementVisitor<Void> {
   protected final Binder binder;
 

--- a/src/com/google/inject/testing/guiceberry/controllable/ControllableInjectionClientModule.java
+++ b/src/com/google/inject/testing/guiceberry/controllable/ControllableInjectionClientModule.java
@@ -25,7 +25,7 @@ import com.google.inject.testing.guiceberry.TestId;
 import java.util.Map;
 
 /**
- * This internal class is basically what the {@link IcMaster} uses to fullfil
+ * This internal class is basically what the {@link IcMaster} uses to fulfill
  * its {@link IcMaster#buildClientModule()} method.
  * 
  * @author Luiz-Otavio Zorzella

--- a/src/com/google/inject/testing/guiceberry/controllable/ControllableInjectionServerModule.java
+++ b/src/com/google/inject/testing/guiceberry/controllable/ControllableInjectionServerModule.java
@@ -24,7 +24,7 @@ import com.google.inject.testing.guiceberry.controllable.IcStrategy.ServerSuppor
 import java.util.Map;
 
 /**
- * This internal class is basically what the {@link IcMaster} uses to fullfil
+ * This internal class is basically what the {@link IcMaster} uses to fulfill
  * its {@link IcMaster#buildServerModule(java.util.Collection)} method.
  * 
  * @author Luiz-Otavio Zorzella

--- a/src/com/google/inject/testing/guiceberry/controllable/IcClient.java
+++ b/src/com/google/inject/testing/guiceberry/controllable/IcClient.java
@@ -59,7 +59,7 @@ public interface IcClient<T> {
    * href="http://www.google.com/codesearch/p?hl=en#yL0uRk1mhCY/trunk/doc/tutorial/test/testng/tutorial_1_server/Example4InjectionControllerTest.java">
    * Example4InjectionControllerTest.java tutorial</a> and others.
    * 
-   * <p>It is ok for a test to call this method multiple times.
+   * <p>It is OK for a test to call this method multiple times.
    */
   void setOverride(T override);
   
@@ -70,7 +70,7 @@ public interface IcClient<T> {
    * test, so you do not need to. This is only provided in case you need to 
    * do so to complete the test altogether.
    * 
-   * <p>It is ok for a test to call this method multiple times, even when
+   * <p>It is OK for a test to call this method multiple times, even when
    * the injection is not currently being controlled, in which case it will
    * be a no-op.
    */

--- a/src/com/google/inject/testing/guiceberry/controllable/IcStrategy.java
+++ b/src/com/google/inject/testing/guiceberry/controllable/IcStrategy.java
@@ -32,7 +32,7 @@ import com.google.inject.util.Types;
  * such as HTTP {@link javax.servlet.http.Cookie}s, {@link java.io.File}s in a 
  * shared disk, shared database tables and whatnot.
  * 
- * <p>This class makes the implementation of these stretegies possible. Each
+ * <p>This class makes the implementation of these strategies possible. Each
  * of these would simply require an implementation of the 
  * {@link IcStrategy.ClientSupport} and {@link IcStrategy.ServerSupport} 
  * interfaces.
@@ -47,7 +47,7 @@ import com.google.inject.util.Types;
  * {@link IcStrategy.ClientSupport#resetOverride(ControllableId)} methods are
  * <em>indirectly</em> exposed to the end-user through 
  * {@link IcClient#setOverride(Object)} and {@link IcClient#resetOverride()}
- * respectivelly.
+ * respectively.
  * 
  * <p>Finally, note that some strategies might be fundamentally more "capable"
  * than others. E.g. a non-serializable class would pose a problem for a 
@@ -107,7 +107,7 @@ public class IcStrategy {
      * Returns true if the {@code controllableId} is currently being controlled.
      * 
      * <p>When this returns true, the framework will call 
-     * {@link #getOverride(ControllableId, Provider)} to fullfil an injection, 
+     * {@link #getOverride(ControllableId, Provider)} to fulfill an injection, 
      * otherwise it will bypass it.
      */
     <T> boolean isControlled(ControllableId<T> controllableId);
@@ -116,7 +116,7 @@ public class IcStrategy {
      * Returns the current override for this Injection. The framework will 
      * never call this method unless {@link #isControlled(ControllableId)} 
      * returns true, so calling this method while not controlling an injection
-     * is illegal and the outcode is unspecified (though it's conceivably 
+     * is illegal and the outcome is unspecified (though it's conceivably 
      * possible to subvert the system with a race condition).
      * 
      * @param delegate what the server would return in absence of this injection 

--- a/src/com/google/inject/testing/guiceberry/junit3/BasicJunit3Module.java
+++ b/src/com/google/inject/testing/guiceberry/junit3/BasicJunit3Module.java
@@ -27,7 +27,7 @@ import junit.framework.TestCase;
  * This Module provides the three basic bindings required by 
  * {@link GuiceBerryJunit3}, namely {@link TestId}, 
  * {@link TestCase} and the {@link TestScoped} scope. Without these three
- * bindinds, {@link GuiceBerryJunit3#setUp(TestCase)} will fail.
+ * bindings, {@link GuiceBerryJunit3#setUp(TestCase)} will fail.
 
  * <p>Thus, this module is all but required to be installed by all 
  * {@link GuiceBerryEnv}s using JUnit3. 

--- a/src/com/google/inject/testing/guiceberry/junit3/GuiceBerryEnvRemapper.java
+++ b/src/com/google/inject/testing/guiceberry/junit3/GuiceBerryEnvRemapper.java
@@ -28,7 +28,7 @@ import junit.framework.TestCase;
  * <p>The primary purpose for this is to allow for running tests under
  * different "integration" modes, as can be seen in the tutorial example
  * {@link junit4.tutorial_0_basic.Example5CustomSelectorTest}.
- * I.e., this allows oen to run any given test against multiple
+ * I.e., this allows one to run any given test against multiple
  * {@link com.google.inject.testing.guiceberry.GuiceBerryEnv}s.
  * 
  * <p>See {@link #remap(TestCase, String)}

--- a/test/com/google/guiceberry/GuiceBerryJunit3Test.java
+++ b/test/com/google/guiceberry/GuiceBerryJunit3Test.java
@@ -450,7 +450,7 @@ public class GuiceBerryJunit3Test extends TearDownTestCase {
     instance().doSetUp(test);
     assertEquals(test,  currentUniverse.currentTestDescriptionThreadLocal.get().getTestCase());
     GuiceBerryJunit3.tearDown(test); 
-  //No concurrency problems as the actual TestCase is: ThreadLocal<TestCase>
+    //No concurrency problems as the actual TestCase is: ThreadLocal<TestCase>
     assertNull(currentUniverse.currentTestDescriptionThreadLocal.get());
   }
   

--- a/test/com/google/guiceberry/controllable/IcMasterTest.java
+++ b/test/com/google/guiceberry/controllable/IcMasterTest.java
@@ -112,7 +112,7 @@ public class IcMasterTest extends TearDownTestCase {
     final IcMaster icMaster = new IcMaster()
       .thatControls(StaticMapInjectionController.strategy(), 
           Key.get(MyEnum.class),
-          // TODO: awkard construct! At least document
+          // TODO: awkward construct! At least document
           Key.get(new TypeLiteral<MyGenericClass<MyEnum>> (){}));
 
     Injector controlledServerInjector = 

--- a/test/com/google/guiceberry/controllable/InterceptingBindingsBuilderTest.java
+++ b/test/com/google/guiceberry/controllable/InterceptingBindingsBuilderTest.java
@@ -87,7 +87,7 @@ public class InterceptingBindingsBuilderTest extends TestCase {
   }
 
   /**
-   * The user's provider is scoped but the interceptor is not. As this testcase
+   * The user's provider is scoped but the interceptor is not. As this test case
    * demonstrates, the user's provider gets called only once (in singleton
    * scope) but the interceptor gets called for each provision.
    */

--- a/test/com/google/inject/testing/guiceberry/controllable/InterceptingBindingsBuilderTest.java
+++ b/test/com/google/inject/testing/guiceberry/controllable/InterceptingBindingsBuilderTest.java
@@ -87,7 +87,7 @@ public class InterceptingBindingsBuilderTest extends TestCase {
   }
 
   /**
-   * The user's provider is scoped but the interceptor is not. As this testcase
+   * The user's provider is scoped but the interceptor is not. As this test case
    * demonstrates, the user's provider gets called only once (in singleton
    * scope) but the interceptor gets called for each provision.
    */


### PR DESCRIPTION
I noticed "bindinds" while browsing code, so I thought I'd go over everything.
For "fullfil" I chose "fulfill" (American) over "fulfil" (British), but I didn't try to "fix" any British spellings (like "behaviour").