### PR TITLE
Allow @TestScoped to play nicely with a shared thread pool

### DIFF
--- a/src/com/google/guiceberry/GuiceBerryUniverse.java
+++ b/src/com/google/guiceberry/GuiceBerryUniverse.java
@@ -389,6 +389,8 @@ class GuiceBerryUniverse {
             + ".setUp()"); 
         throw new RuntimeException(msg); 
       }
+      testDescription.setFinished(true);
+      // only remove a reference from this thread, children threads still have it
       universe.currentTestDescriptionThreadLocal.remove();
       injector.getInstance(TestScope.class).finishScope(testDescription);    
     }

--- a/src/com/google/guiceberry/TestDescription.java
+++ b/src/com/google/guiceberry/TestDescription.java
@@ -38,6 +38,8 @@ public final class TestDescription {
   private final Object testCase;
   private final String name;
   private final TestId testId;
+  /** Is set to true on the main test thread, read by children threads. */
+  private volatile boolean finished;
 
   /**
    * You won't have to create an instance of this class unless you are writing a
@@ -58,6 +60,7 @@ public final class TestDescription {
     this.testCase = Preconditions.checkNotNull(testCase);
     this.name = mangle(Preconditions.checkNotNull(name));
     this.testId = new TestId(name);
+    finished = false;
   }
   
   private static String mangle(String name) {
@@ -82,7 +85,17 @@ public final class TestDescription {
   TestId getTestId() {
     return testId;
   }
-  
+
+  /** Has this test finished yet? */
+  boolean isFinished() {
+    return finished;
+  }
+
+  /** Mark this test as finished. */
+  void setFinished(boolean finished) {
+    this.finished = finished;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {

--- a/src/com/google/guiceberry/TestScoped.java
+++ b/src/com/google/guiceberry/TestScoped.java
@@ -26,7 +26,12 @@ import com.google.inject.ScopeAnnotation;
 
 /**
  * This defines a {@link Scope} that begins during test "set up" and ends during
- * test "tear down".
+ * test "tear down". Creates no more than one object per test thread and its
+ * children threads during a test run. When two tests share a thread pool
+ * exception will be thrown when the thread is reused as there is no way to
+ * determine a parent test when several tests are run in parallel. You may
+ * explicitly reset a thread's state by using
+ * {@link TestScope#setInternalStateForCurrentThread}.
  * 
  * @see TestScope implementation details
  * 

--- a/test/com/google/guiceberry/TestScopeTest.java
+++ b/test/com/google/guiceberry/TestScopeTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.guiceberry;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Provider;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.guiceberry.junit4.GuiceBerryRule;
+import com.google.inject.Inject;
+import com.google.inject.ProvisionException;
+
+/**
+ * Tests for {@link TestScope}.
+ *
+ * @author Timothy Basanov (timofey.basanov@gmail.com)
+ */
+public class TestScopeTest {
+
+  /** Use default GuiceBerry configuration to get a {@link TestScoped} {@link TestId}. */
+  @Rule public final GuiceBerryRule guiceBerryRule =
+      new GuiceBerryRule(GuiceBerryModule.class);
+
+  /** Directly injected value always matches the current test id. */
+  @Inject TestId expectedTestId;
+  /** Provider relies internally on a {@link TestScope}. */
+  @Inject Provider<TestId> testIdProvider;
+  /** {@link javax.inject.Singleton} {@link TestScope} itself. */
+  @Inject TestScope testScope;
+
+  /** Shorthand to read a test scoped test id from a different thread. */
+  class GetProvidedTestId implements Callable<TestId> {
+    public TestId call() throws Exception {
+      return testIdProvider.get();
+    }
+  }
+
+  /** Thread detached from any specific test. */
+  static final ExecutorService detachedThread =
+      Executors.newSingleThreadExecutor();
+  static {
+    detachedThread.execute(new Runnable() {
+      public void run() {
+        // task execution would enforce a thread creation outside of any test
+      }
+    });
+  }
+
+  /** Thread shared between two tests, should be created in the first test. */
+  static final ExecutorService sharedThread =
+      Executors.newSingleThreadExecutor();
+  static final AtomicInteger sharedThreadTestCounter = new AtomicInteger(0);
+
+  /** Verify that test id is scoped right within the main thread. */
+  @Test
+  public void testSameThreadSameTestId() throws Exception {
+    TestId actualTestId =
+        MoreExecutors.newDirectExecutorService().submit(new GetProvidedTestId()).get();
+    Assert.assertSame(expectedTestId, actualTestId);
+  }
+
+  /** Threads created within a test inherit test scope. */
+  @Test
+  public void testChildThreadSameTestId() throws Exception {
+    TestId actualTestId =
+        Executors.newSingleThreadExecutor().submit(new GetProvidedTestId()).get();
+    Assert.assertSame(expectedTestId, actualTestId);
+  }
+
+  /** Verify that detached thread does not share a test scope. */
+  @Test
+  public void testDetachedThreadNoTestId() throws Exception {
+    try {
+      detachedThread.submit(new GetProvidedTestId()).get();
+      Assert.fail("Detached thread should not share a test scope");
+    } catch (ExecutionException e) {
+      Assert.assertSame(ProvisionException.class, e.getCause().getClass());
+      Assert.assertSame(IllegalStateException.class, e.getCause().getCause().getClass());
+      Assert.assertTrue(e.getCause().getCause().getMessage().contains("GuiceBerry"));
+    }
+
+    final TestScope.InternalState internalState =
+        testScope.getInternalStateForCurrentThread();
+    detachedThread.submit(new Runnable() {
+      public void run() {
+        testScope.setInternalStateForCurrentThread(internalState);
+      }
+    }).get();
+
+    TestId actualTestId = detachedThread.submit(new GetProvidedTestId()).get();
+    Assert.assertSame(expectedTestId, actualTestId);
+  }
+
+  /** Verify two tests sharing the same thread. */
+  @Test
+  public void testSharedThreadA() throws Exception {
+    testSharedThread();
+  }
+
+  /** Verify two tests sharing the same thread. */
+  @Test
+  public void testSharedThreadB() throws Exception {
+    testSharedThread();
+  }
+
+  /** Execute tests 1 and 2 sequentially in a predictable order. */
+  void testSharedThread() throws Exception {
+    synchronized (sharedThreadTestCounter) {
+      int counter = sharedThreadTestCounter.incrementAndGet();
+      if (counter == 1) {
+        testSharedThreadTest1SameTestId();
+      } else if (counter == 2) {
+        testSharedThreadTest2NoTestId();
+      } else {
+        Assert.fail();
+      }
+    }
+  }
+
+  /** First test creating the thread shares the test scope. */
+  void testSharedThreadTest1SameTestId() throws Exception {
+    TestId actualTestId = sharedThread.submit(new GetProvidedTestId()).get();
+    Assert.assertSame(expectedTestId, actualTestId);
+  }
+
+  /** Second test should not share scope with the first test. */
+  void testSharedThreadTest2NoTestId() throws Exception {
+    try {
+      sharedThread.submit(new GetProvidedTestId()).get();
+      Assert.fail("Test1 already finished and its test scope should be closed");
+    } catch (ExecutionException e) {
+      Assert.assertSame(ProvisionException.class, e.getCause().getClass());
+      Assert.assertSame(IllegalStateException.class, e.getCause().getCause().getClass());
+      Assert.assertTrue(e.getCause().getCause().getMessage().contains("GuiceBerry"));
+    }
+
+    final TestScope.InternalState internalState =
+        testScope.getInternalStateForCurrentThread();
+    sharedThread.submit(new Runnable() {
+      public void run() {
+        testScope.setInternalStateForCurrentThread(internalState);
+      }
+    }).get();
+
+    TestId actualTestId = sharedThread.submit(new GetProvidedTestId()).get();
+    Assert.assertSame(expectedTestId, actualTestId);
+  }
+}


### PR DESCRIPTION
Resolves: https://github.com/zorzella/guiceberry/issues/35

Changes TestScope contract to explicitly propagate to children
threads and to be explicitly closed when test execution is finished.
This prevents several threads from accidentally sharing the same
ThreadScope by reusing a thread pool.

Add an additional API to allow TestScope propagation to non-children
threads and shared thread pools:
InternalState TestScope.getInternalStateForCurrentThread();
void TestScope.setInternalStateForCurrentThread(InternalState);

This allows testing of multi-threaded servers that have
a static internal thread pool shared between tests.